### PR TITLE
Rebranding updates

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -7,7 +7,7 @@ This topic describes the Metric Registrar for Pivotal Application Service (PAS).
 
 ## <a id="overview"></a> Overview 
 
-The Metric Registrar allows app developers to export custom app metrics in a format that Loggregator can consume. App developers can then use the custom metrics to monitor apps with PCF Metrics and configure autoscaling rules with PCF Autoscaler. 
+The Metric Registrar allows app developers to export custom app metrics in a format that Loggregator can consume. App developers can then use the custom metrics to monitor apps with Pivotal App Metrics and configure autoscaling rules with Pivotal Autoscaler. 
 
 App developers can export custom metrics to Loggregator by configuring their apps in one of the following ways:
 
@@ -18,8 +18,8 @@ For more information about installing the Metric Registrar Plugin and registerin
 
 For more information about the components and products mentioned, see the following:
 - [Loggregator](https://docs.pivotal.io/pivotalcf/loggregator/architecture.html)
-- [PCF Metrics](https://docs.pivotal.io/pcf-metrics)
-- [PCF Autoscaler](https://docs.pivotal.io/pivotalcf/appsman-services/autoscaler/using-autoscaler.html)
+- [Pivotal App Metrics](https://docs.pivotal.io/pcf-metrics)
+- [Pivotal Autoscaler](https://docs.pivotal.io/pivotalcf/appsman-services/autoscaler/using-autoscaler.html)
 
 ## <a id="architecture"></a> Architecture 
 


### PR DESCRIPTION
Removed all mention of "PCF" in favor of "Pivotal". 

I think I remember hearing that URLs don't need to be changed? The only remaining mention of PCF if is in the URL for PCF Metrics, which I left, assuming the URL will redirect in the future. 

I assume we're rebranding the docs for all supported PAS versions? If that's the case, I could use a hand backporting these changes. 