### PR TITLE
As of version 1.3.1 it's required to pass --insecure flag

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -95,6 +95,7 @@ To register a public metrics endpoint for an app:
 	<p class='note'><strong>Note:</strong> When specifying a path to a metrics endpoint, the path must start with a <code>/</code> character.</p>
 	<p class='note'><strong>Note:</strong> When specifying a URL to a metrics endpoint, the scheme must be omitted and the URL must use HTTPS.
 	<p class='note'><strong>Note:</strong> Each metrics endpoint registered with Metric Registrar creates a service instance. If the generated service name is longer than 50 characters, it is encoded with a hash.</p>
+	<p class='note'><strong>Note:</strong> As of version 1.3.1, <code>--insecure</code> flag is required for the same values provided in pervious versions.</p>
 
 #### <a id="endpoint-verify"></a> Verify a Metrics Endpoint
 


### PR DESCRIPTION
for the same input that was previously considered not required.