### PR TITLE
Retrieving metrics from an arbitrary URL is not supported

### DIFF
--- a/using.html.md.erb
+++ b/using.html.md.erb
@@ -87,7 +87,7 @@ To register a public metrics endpoint for an app:
     ```
     cf register-metrics-endpoint example /metrics --insecure
     ```
-    Or, if pulling metrics from a different URL:
+    Or, if pulling metrics by specifying an alternative route also mapped to the same app:
 
     ```
     cf register-metrics-endpoint example otherexample.com/metrics --insecure


### PR DESCRIPTION
The existing wording was unclear and could be interpreted by users as allowing a metrics endpoint to be registered for an arbitrary URL, this is not correct. We only support pulling metrics from routes mapped to the application.